### PR TITLE
feat(core): move responsive-row markup to table syntax

### DIFF
--- a/packages/core/src/create-responsive-row.tsx
+++ b/packages/core/src/create-responsive-row.tsx
@@ -58,40 +58,55 @@ export function createResponsiveRow<SectionProps extends BaseSectionProps>(
       (props.maxWidth ?? 600 - pl - pr) / totalColumnSpan;
 
     return (
-      <Section
+      <table
+        align="center"
+        width="100%"
         style={{
           textAlign: "center",
           fontSize: 0,
-          padding: `${props.paddingTop ?? 0}px ${props.paddingRight ?? 0}px ${
-            props.paddingBottom ?? 0
-          }px ${props.paddingLeft ?? 0}px`,
           ...props.style,
         }}
+        border={0}
+        cellPadding="0"
+        cellSpacing="0"
+        role="presentation"
       >
-        {childrenArray.map((node, i) => {
-          if (isResponsiveColumn(node)) {
-            const columnProps = node.props;
-            const columnSpan = columnProps.span ?? 1;
+        <tbody>
+          <tr>
+            <td
+              style={{
+                padding: `${props.paddingTop ?? 0}px ${
+                  props.paddingRight ?? 0
+                }px ${props.paddingBottom ?? 0}px ${props.paddingLeft ?? 0}px`,
+              }}
+            >
+              {childrenArray.map((node, i) => {
+                if (isResponsiveColumn(node)) {
+                  const columnProps = node.props;
+                  const columnSpan = columnProps.span ?? 1;
 
-            return (
-              <Section
-                {...columnProps}
-                key={i}
-                style={{
-                  maxWidth: oneColumnMaxWidth * columnSpan,
-                  display: "inline-block",
-                  verticalAlign: "top",
-                  fontSize: 16,
-                  boxSizing: "border-box",
-                  ...columnProps.style,
-                }}
-              />
-            );
-          }
+                  return (
+                    <Section
+                      {...columnProps}
+                      key={i}
+                      style={{
+                        maxWidth: oneColumnMaxWidth * columnSpan,
+                        display: "inline-block",
+                        verticalAlign: "top",
+                        fontSize: 16,
+                        boxSizing: "border-box",
+                        ...columnProps.style,
+                      }}
+                    />
+                  );
+                }
 
-          return node;
-        })}
-      </Section>
+                return node;
+              })}
+            </td>
+          </tr>
+        </tbody>
+      </table>
     );
   };
 }

--- a/samples/emails/double-layout.tsx
+++ b/samples/emails/double-layout.tsx
@@ -160,4 +160,5 @@ const main = {
 const container = {
   margin: "0 auto",
   paddingTop: 42,
+  maxWidth: "600px",
 };

--- a/samples/emails/mixed-layout.tsx
+++ b/samples/emails/mixed-layout.tsx
@@ -10,6 +10,8 @@ import {
   Text,
   Heading,
   Button,
+  Row,
+  Column,
 } from "@react-email/components";
 import * as React from "react";
 import { ResponsiveRow, ResponsiveColumn } from "@responsive-email/react-email";
@@ -52,36 +54,44 @@ export const MixedLayoutTemplate = () => (
             </Link>
           </ResponsiveColumn>
         </ResponsiveRow>
-        <Section
+        <Row
           style={{
             backgroundImage: `url("/static/img/banner-bg.jpg")`,
             backgroundSize: "cover",
             width: "100%",
-            padding: "48px 16px 64px",
             textAlign: "center",
             color: "white",
           }}
         >
-          <Heading as="h2" style={{ fontSize: 28 }}>
-            A Modern Design Agency
-          </Heading>
-          <Text style={{ marginBottom: 32, fontSize: 16 }}>
-            We help your brand go viral to connect you with your customers and
-            grow organically!
-          </Text>
-          <Button
+          <Column
             style={{
-              padding: "16px 20px",
-              background: "#171a1b",
-              color: "white",
-              textTransform: "uppercase",
-              fontWeight: "bold",
-              borderRadius: 5,
+              padding: "48px 16px 64px",
             }}
           >
-            Get started
-          </Button>
-        </Section>
+            <Heading as="h2" style={{ fontSize: 28, textAlign: "center" }}>
+              A Modern Design Agency
+            </Heading>
+            <Text
+              style={{ marginBottom: 32, fontSize: 16, textAlign: "center" }}
+            >
+              We help your brand go viral to connect you with your customers and
+              grow organically!
+            </Text>
+            <Button
+              style={{
+                padding: "16px 20px",
+                background: "#171a1b",
+                color: "white",
+                textTransform: "uppercase",
+                fontWeight: "bold",
+                borderRadius: 5,
+                margin: "0 auto",
+              }}
+            >
+              Get started
+            </Button>
+          </Column>
+        </Row>
         <ResponsiveRow paddingTop={15} paddingBottom={15}>
           <ResponsiveColumn>
             <Link href="#">
@@ -163,60 +173,69 @@ export const MixedLayoutTemplate = () => (
             </Button>
           </ResponsiveColumn>
         </ResponsiveRow>
-        <Section style={{ textAlign: "center", padding: "20px 20px 40px" }}>
-          <Heading as="h3">HTML Email Template Course</Heading>
-          <Text style={{ padding: "0 0 15px" }}>
-            Responsive HTML Email Templates that you can build around.
-            Responsive HTML Email Templates that you can build around.
-            Responsive HTML Email Templates that you can build around.
-            Responsive HTML Email Templates that you can build around.
-          </Text>
-          <Button
-            style={{
-              padding: "12px 20px",
-              background: "#171a1b",
-              color: "white",
-              borderRadius: 5,
-              fontWeight: "bold",
-            }}
-          >
-            View Course
-          </Button>
-        </Section>
-        <Section
+        <Row style={{ textAlign: "center" }}>
+          <Column style={{ padding: "20px 20px 40px" }}>
+            <Heading as="h3" style={{ textAlign: "center" }}>
+              HTML Email Template Course
+            </Heading>
+            <Text style={{ padding: "0 0 15px", textAlign: "center" }}>
+              Responsive HTML Email Templates that you can build around.
+              Responsive HTML Email Templates that you can build around.
+              Responsive HTML Email Templates that you can build around.
+              Responsive HTML Email Templates that you can build around.
+            </Text>
+            <Button
+              style={{
+                padding: "12px 20px",
+                background: "#171a1b",
+                color: "white",
+                borderRadius: 5,
+                fontWeight: "bold",
+                margin: "0 auto",
+              }}
+            >
+              View Course
+            </Button>
+          </Column>
+        </Row>
+        <Row
           style={{
             textAlign: "center",
             color: "white",
             background: "#171a1b",
-            padding: "20px 20px 40px",
           }}
         >
-          <img src="/static/img/modern-white.png" width={180} />
-          <Text>Modern HTML Email</Text>
-          <Text style={{ marginBottom: 10 }}>
-            123 Street Road City, State 55555
-          </Text>
-          <div style={{ padding: "20px 0" }}>
-            <Link href="#" style={{ fontSize: 0 }}>
-              <img src="/static/img/white-facebook.png" width={30} />
+          <Column style={{ padding: "20px 20px 40px" }}>
+            <img src="/static/img/modern-white.png" width={180} />
+            <Text>Modern HTML Email</Text>
+            <Text style={{ marginBottom: 10 }}>
+              123 Street Road City, State 55555
+            </Text>
+            <div style={{ padding: "20px 0" }}>
+              <Link href="#" style={{ fontSize: 0 }}>
+                <img src="/static/img/white-facebook.png" width={30} />
+              </Link>
+              <Link href="#" style={{ fontSize: 0 }}>
+                <img src="/static/img/white-twitter.png" width={30} />
+              </Link>
+              <Link href="#" style={{ fontSize: 0 }}>
+                <img src="/static/img/white-youtube.png" width={30} />
+              </Link>
+              <Link href="#" style={{ fontSize: 0 }}>
+                <img src="/static/img/white-linkedin.png" width={30} />
+              </Link>
+              <Link href="#" style={{ fontSize: 0 }}>
+                <img src="/static/img/white-instagram.png" width={30} />
+              </Link>
+            </div>
+            <Link
+              href="#"
+              style={{ textTransform: "uppercase", color: "white" }}
+            >
+              Subscribe
             </Link>
-            <Link href="#" style={{ fontSize: 0 }}>
-              <img src="/static/img/white-twitter.png" width={30} />
-            </Link>
-            <Link href="#" style={{ fontSize: 0 }}>
-              <img src="/static/img/white-youtube.png" width={30} />
-            </Link>
-            <Link href="#" style={{ fontSize: 0 }}>
-              <img src="/static/img/white-linkedin.png" width={30} />
-            </Link>
-            <Link href="#" style={{ fontSize: 0 }}>
-              <img src="/static/img/white-instagram.png" width={30} />
-            </Link>
-          </div>
-          <Link href="#" style={{ textTransform: "uppercase", color: "white" }}>
-            Subscribe
-          </Link>
-        </Section>
+          </Column>
+        </Row>
       </Container>
     </Body>
   </Html>
@@ -232,4 +251,5 @@ const main = {
 const container = {
   backgroundColor: "#ffffff",
   margin: "0 auto",
+  maxWidth: "600px",
 };

--- a/samples/emails/single-layout.tsx
+++ b/samples/emails/single-layout.tsx
@@ -22,39 +22,45 @@ export const SingleLayoutTemplate = () => (
 
     <Body style={main}>
       <Container style={container}>
-        <Section style={colPadding}>
-          <Heading
-            as="h1"
-            style={{ fontSize: 24, color: "#17BEBB", fontWeight: "bolder" }}
-          >
-            Shop
-          </Heading>
-        </Section>
-        <Section style={colPadding}>
-          <Heading
-            as="h2"
-            style={{
-              fontSize: 34,
-              fontWeight: 400,
-              marginBottom: 14,
-              letterSpacing: 1,
-            }}
-          >
-            Ronald your shopping cart misses you
-          </Heading>
-        </Section>
-        <Section style={colPadding}>
-          <Text
-            style={{
-              fontSize: 24,
-              marginBottom: 24,
-              lineHeight: 1.8,
-              fontWeight: 300,
-            }}
-          >
-            Amazing deals, updates, interesting news right in your inbox
-          </Text>
-        </Section>
+        <Row>
+          <Column style={colPadding}>
+            <Heading
+              as="h1"
+              style={{ fontSize: 24, color: "#17BEBB", fontWeight: "bolder" }}
+            >
+              Shop
+            </Heading>
+          </Column>
+        </Row>
+        <Row>
+          <Column style={colPadding}>
+            <Heading
+              as="h2"
+              style={{
+                fontSize: 34,
+                fontWeight: 400,
+                marginBottom: 14,
+                letterSpacing: 1,
+              }}
+            >
+              Ronald your shopping cart misses you
+            </Heading>
+          </Column>
+        </Row>
+        <Row>
+          <Column style={colPadding}>
+            <Text
+              style={{
+                fontSize: 24,
+                marginBottom: 24,
+                lineHeight: 1.8,
+                fontWeight: 300,
+              }}
+            >
+              Amazing deals, updates, interesting news right in your inbox
+            </Text>
+          </Column>
+        </Row>
         <Section>
           <Row
             style={{
@@ -138,19 +144,21 @@ export const SingleLayoutTemplate = () => (
             <Column style={{ fontSize: 16, textAlign: "center" }}>$120</Column>
           </Row>
         </Section>
-        <Section style={{ ...colPadding, paddingTop: 15, paddingBottom: 15 }}>
-          <Button
-            style={{
-              background: "#17BEBB",
-              color: "white",
-              borderRadius: 5,
-              margin: "10px 0",
-              padding: "10px 16px",
-            }}
-          >
-            Continue your order
-          </Button>
-        </Section>
+        <Row>
+          <Column style={{ ...colPadding, paddingTop: 15, paddingBottom: 15 }}>
+            <Button
+              style={{
+                background: "#17BEBB",
+                color: "white",
+                borderRadius: 5,
+                margin: "10px 0",
+                padding: "10px 16px",
+              }}
+            >
+              Continue your order
+            </Button>
+          </Column>
+        </Row>
         <ResponsiveRow
           paddingTop={24}
           paddingBottom={24}
@@ -225,14 +233,16 @@ export const SingleLayoutTemplate = () => (
             </Section>
           </ResponsiveColumn>
         </ResponsiveRow>
-        <Section style={{ ...colPadding, textAlign: "center" }}>
-          <Text style={{ color: "rgba(0,0,0, 0.4)", margin: "15px 0" }}>
-            No longer want to receive these emails? You can{" "}
-            <Link href="#" style={{ color: "rgba(0,0,0,0.8)" }}>
-              Unsubscribe here
-            </Link>
-          </Text>
-        </Section>
+        <Row style={{ textAlign: "center" }}>
+          <Column style={colPadding}>
+            <Text style={{ color: "rgba(0,0,0, 0.4)", margin: "15px 0" }}>
+              No longer want to receive these emails? You can{" "}
+              <Link href="#" style={{ color: "rgba(0,0,0,0.8)" }}>
+                Unsubscribe here
+              </Link>
+            </Text>
+          </Column>
+        </Row>
       </Container>
     </Body>
   </Html>
@@ -246,6 +256,7 @@ const main = {
 };
 
 const container = {
+  maxWidth: "600px",
   backgroundColor: "#ffffff",
   margin: "0 auto",
   paddingTop: 32,


### PR DESCRIPTION
### Description 
This PR updates the `responsive-row` wrapper in `core` from a `Section` instance to `table => t => td` syntax for correct application of padding and also updates sample templates markup