### PR TITLE
chore: Add more flexibility to the `<ResponsiveColumn>` component

### DIFF
--- a/packages/core/src/create-responsive-column.tsx
+++ b/packages/core/src/create-responsive-column.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import { BaseSectionProps } from "./base-section-props";
 
-export type ResponsiveColumnProps<SectionProps extends BaseSectionProps> = SectionProps & {
+export type ResponsiveColumnProps = React.ComponentPropsWithoutRef<'table'> & {
   span?: number;
+  tdProps?: React.ComponentPropsWithoutRef<'td'>;
 };
 
-export function createResponsiveColumn<TSection extends BaseSectionProps>() {
-
+export function createResponsiveColumn() {
   const ResponsiveColumn = (_props: BaseSectionProps) => {
     /*
       This component is basically just a placeholder that we then get the props from.
@@ -31,14 +31,14 @@ export function createResponsiveColumn<TSection extends BaseSectionProps>() {
     isResponsiveColumn: (
       node: any,
     ): node is React.ReactElement<
-      ResponsiveColumnProps<TSection>,
+      ResponsiveColumnProps,
       typeof ResponsiveColumn
     > => {
       return (
-        React.isValidElement<ResponsiveColumnProps<TSection>>(node) &&
+        React.isValidElement<ResponsiveColumnProps>(node) &&
         node.type === ResponsiveColumn
       );
     },
-    component: ResponsiveColumn as React.FC<ResponsiveColumnProps<TSection>>,
+    component: ResponsiveColumn as React.FC<ResponsiveColumnProps>,
   };
 }

--- a/packages/core/src/create-responsive-row.tsx
+++ b/packages/core/src/create-responsive-row.tsx
@@ -1,11 +1,7 @@
 import React from "react";
 import { ResponsiveColumnProps } from "./create-responsive-column";
-import { BaseSectionProps } from "./base-section-props";
 
-export type ResponsiveRowProps<SectionProps extends BaseSectionProps> = Omit<
-  SectionProps,
-  "style"
-> & {
+export type ResponsiveRowProps = Omit<React.ComponentPropsWithoutRef<'table'>, 'style'> & {
   style?: Omit<
     React.CSSProperties,
     | "padding"
@@ -26,16 +22,15 @@ export type ResponsiveRowProps<SectionProps extends BaseSectionProps> = Omit<
   paddingBottom?: number;
 };
 
-export function createResponsiveRow<SectionProps extends BaseSectionProps>(
-  Section: React.FC<BaseSectionProps>,
+export function createResponsiveRow(
   isResponsiveColumn: (
-    node: any
+    node: any,
   ) => node is React.ReactElement<
-    ResponsiveColumnProps<SectionProps>,
-    React.FC<ResponsiveColumnProps<SectionProps>>
-  >
+    ResponsiveColumnProps,
+    React.FC<ResponsiveColumnProps>
+  >,
 ) {
-  return (props: ResponsiveRowProps<SectionProps>) => {
+  return (props: ResponsiveRowProps) => {
     const childrenArray = React.Children.toArray(props.children);
 
     const responsiveColumns = childrenArray
@@ -43,13 +38,13 @@ export function createResponsiveRow<SectionProps extends BaseSectionProps>(
       .map((node) => node.props.span ?? 1);
     if (responsiveColumns.length > 3) {
       console.warn(
-        "You've exceeded the recommended 3-column limit in your email template. Consider sticking to a maximum of 3 columns for best practice."
+        "You've exceeded the recommended 3-column limit in your email template. Consider sticking to a maximum of 3 columns for best practice.",
       );
     }
 
     const totalColumnSpan = responsiveColumns.reduce(
       (acc, spanForColumn) => acc + spanForColumn,
-      0
+      0,
     );
 
     const pl = props.paddingLeft ?? 0;
@@ -61,15 +56,16 @@ export function createResponsiveRow<SectionProps extends BaseSectionProps>(
       <table
         align="center"
         width="100%"
+        border={0}
+        cellPadding="0"
+        cellSpacing="0"
+        role="presentation"
+        {...props}
         style={{
           textAlign: "center",
           fontSize: 0,
           ...props.style,
         }}
-        border={0}
-        cellPadding="0"
-        cellSpacing="0"
-        role="presentation"
       >
         <tbody>
           <tr>
@@ -86,9 +82,15 @@ export function createResponsiveRow<SectionProps extends BaseSectionProps>(
                   const columnSpan = columnProps.span ?? 1;
 
                   return (
-                    <Section
-                      {...columnProps}
+                    <table
                       key={i}
+                      align="center"
+                      width="100%"
+                      border={0}
+                      cellPadding="0"
+                      cellSpacing="0"
+                      role="presentation"
+                      {...columnProps}
                       style={{
                         maxWidth: oneColumnMaxWidth * columnSpan,
                         display: "inline-block",
@@ -97,7 +99,13 @@ export function createResponsiveRow<SectionProps extends BaseSectionProps>(
                         boxSizing: "border-box",
                         ...columnProps.style,
                       }}
-                    />
+                    >
+                      <tbody>
+                        <tr>
+                          <td {...columnProps.tdProps}>{columnProps.children}</td>
+                        </tr>
+                      </tbody>
+                    </table>
                   );
                 }
 

--- a/packages/jsx-email/src/responsive-column.ts
+++ b/packages/jsx-email/src/responsive-column.ts
@@ -1,10 +1,9 @@
-import { SectionProps } from "jsx-email";
 import {
   createResponsiveColumn,
   ResponsiveColumnProps as BaseProps,
 } from "@responsive-email/core";
 
-export type ResponsiveColumnProps = BaseProps<SectionProps>;
+export type ResponsiveColumnProps = BaseProps;
 
 export const { isResponsiveColumn, component: ResponsiveColumn } =
-  createResponsiveColumn<SectionProps>();
+  createResponsiveColumn();

--- a/packages/jsx-email/src/responsive-row.ts
+++ b/packages/jsx-email/src/responsive-row.ts
@@ -1,11 +1,10 @@
-import { Section, SectionProps } from "jsx-email";
 import { isResponsiveColumn } from "./responsive-column";
 import {
   ResponsiveRowProps as BaseProps,
   createResponsiveRow,
 } from "@responsive-email/core";
 
-export type ResponsiveRowProps = BaseProps<SectionProps>;
+export type ResponsiveRowProps = BaseProps;
 
 /**
  * @example
@@ -16,7 +15,6 @@ export type ResponsiveRowProps = BaseProps<SectionProps>;
  * </ResponsiveRow>
  * ```
  */
-export const ResponsiveRow = createResponsiveRow<SectionProps>(
-  Section,
+export const ResponsiveRow = createResponsiveRow(
   isResponsiveColumn
 );

--- a/packages/react-email/src/responsive-column.ts
+++ b/packages/react-email/src/responsive-column.ts
@@ -1,10 +1,9 @@
-import { SectionProps } from "@react-email/section";
 import {
   createResponsiveColumn,
   ResponsiveColumnProps as BaseProps,
 } from "@responsive-email/core";
 
-export type ResponsiveColumnProps = BaseProps<SectionProps>;
+export type ResponsiveColumnProps = BaseProps;
 
 export const { isResponsiveColumn, component: ResponsiveColumn } =
-  createResponsiveColumn<SectionProps>();
+  createResponsiveColumn();

--- a/packages/react-email/src/responsive-row.ts
+++ b/packages/react-email/src/responsive-row.ts
@@ -1,11 +1,10 @@
-import { Section, SectionProps } from "@react-email/section";
 import { isResponsiveColumn } from "./responsive-column";
 import {
   ResponsiveRowProps as BaseProps,
   createResponsiveRow,
 } from "@responsive-email/core";
 
-export type ResponsiveRowProps = BaseProps<SectionProps>;
+export type ResponsiveRowProps = BaseProps;
 
 /**
  * @example
@@ -16,7 +15,6 @@ export type ResponsiveRowProps = BaseProps<SectionProps>;
  * </ResponsiveRow>
  * ```
  */
-export const ResponsiveRow = createResponsiveRow<SectionProps>(
-  Section,
+export const ResponsiveRow = createResponsiveRow(
   isResponsiveColumn
 );


### PR DESCRIPTION
What this does is not use a Section, and use a direct table allowing for all the props to the table and allowing for all the props inside of the inner `<td>` in the table through a new `tdProps` property.

This should improve the flexibility without much of a down side.